### PR TITLE
add ^7.0.1 version support to @nestjs/common peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "prepublish": "npm run format && npm run build"
   },
   "peerDependencies": {
-    "@nestjs/common": "^5.1.0 || ^6.0.3"
+    "@nestjs/common": "^5.1.0 || ^6.0.3 || ^7.0.1"
   },
   "dependencies": {
     "dotenv": "^8.0.0",


### PR DESCRIPTION
This fix solves issue [310](https://github.com/nestjsx/nestjs-config/issues/310) by adding 7.x version support to `@nestjs/common` peer dependency. As of right now `npm install nestjs-config` with latest node version will fail without `--legacy-peer-deps` flag, if `@nestjs/common@^7.0.0` is present in projects dependencies. Aside from this dependency issue, this library works well with `@nestjs/common@^7.0.0` as far as I know.